### PR TITLE
Fix ftdetect hanging in some cases

### DIFF
--- a/ftdetect/neuron.vim
+++ b/ftdetect/neuron.vim
@@ -7,7 +7,7 @@ if s:current == ''
 	let s:current = getcwd()
 endif
 let s:dir = fnamemodify(s:current, ":h:r")
-while s:dir != "/"
+while s:dir != "/" && s:dir != "."
 	if filereadable(s:dir."/neuron.dhall")
 		let g:zkdir = s:dir."/"
 		break

--- a/ftdetect/neuron.vim
+++ b/ftdetect/neuron.vim
@@ -3,6 +3,9 @@ let g:zkdir = get(g:, 'zkdir', $HOME.'/zettelkasten/')
 
 " search for neuron.dhall
 let s:current = expand("%:p")
+if s:current == ''
+	let s:current = getcwd()
+endif
 let s:dir = fnamemodify(s:current, ":h:r")
 while s:dir != "/"
 	if filereadable(s:dir."/neuron.dhall")


### PR DESCRIPTION
During the ftdetect we attempt to find the `neuron.dhall` that's relevant to the opened file. We do this by looking in the same directory as the opened file, and then its parent, and then its parent's parent, and so on. When we reach root (`/`) we bail out and assume we're not in a zettelkasten.

When opening (n)vim without passing any files to open a new buffer is opened. No path is associated with this buffer, so `expand("%:p")` returns an empty string. When we then try to use this as a filename in `fnamemodify("", ":h:r")` this returns `.`. If the current directory has a `neuron.dhall` file this works out, as we then check for `./neuron.dhall`, find it, and continue. If it does not we have a problem, as `fnamemodify(".", ":h:r")` returns `.`, putting us in an endless loop.

This change handles this by falling back on `getcwd()` if `expand("%:p")` returns an empty string.

Fixes #4.