### PR TITLE
Rename/document some `g:neuron_` variables.

### DIFF
--- a/autoload/rpc.vim
+++ b/autoload/rpc.vim
@@ -1,13 +1,13 @@
 func! s:on_exit(chan_id, data, ...) abort
-	let g:neuron_rib_job = -1
+	let g:_neuron_rib_job = -1
 endf
 
 func! rpc#start_server()
 	let options = {
 		\ 'on_exit': function('s:on_exit'),
 	\}
-	if g:neuron_rib_job == -1
-		let g:neuron_rib_job = jobstart(['neuron', 'rib', '-wS'], options)
+	if g:_neuron_rib_job == -1
+		let g:_neuron_rib_job = jobstart(['neuron', 'rib', '-wS'], options)
 		echom 'Neuron rib server started.'
 	end
 	echom 'Opening http://127.0.0.1:8080/...'
@@ -15,10 +15,10 @@ func! rpc#start_server()
 endf
 
 func! rpc#stop_server()
-	if g:neuron_rib_job != -1
-		call jobstop(g:neuron_rib_job)
+	if g:_neuron_rib_job != -1
+		call jobstop(g:_neuron_rib_job)
 		echom('Neuron rib server stopped.')
-		let g:neuron_rib_job = -1
+		let g:_neuron_rib_job = -1
 	else
 		echom 'Neuron rib server is not running already!'
 	end

--- a/autoload/util.vim
+++ b/autoload/util.vim
@@ -63,7 +63,7 @@ func! util#edit_shrink_fzf(line)
 endf
 
 func! util#handlerr(errcode)
-	let l:neuron_errors = deepcopy(g:neuron_errors)
+	let l:neuron_errors = deepcopy(g:_neuron_errors)
 	let l:err = l:neuron_errors[a:errcode]
 	let l:errmsg='neuron: '.a:errcode.': '.l:err['problem']
 	if len(l:err['suggestions']) > 0

--- a/doc/neuron.vim.txt
+++ b/doc/neuron.vim.txt
@@ -7,6 +7,9 @@ INTRODUCTION                                    *neuron.vim*
 neuron.vim manages your zettelkasten. You can search, create, navigate and open your zettels using fzf and neuron.
 
 CONFIGURATION                                   *neuron.vim-configuration*
+g:neuron_dir                Zettelkasten location. Default: >
+                            let g:neuron_dir = getcwd()
+
 g:neuron_extension          Zettel file extension. Default: >
                             let g:neuron_extension = '.md'
 
@@ -18,6 +21,9 @@ g:neuron_fzf_options        Change the fzf parameters. Default: >
 
 g:neuron_executable         Path to neuron. Default >
                             let g:neuron_executable = system('which neuron | tr -d "\n"')
+
+g:neuron_no_mappings        If this is set to 1 no mappings will be created. Default: >
+                            let g:neuron_no_mappings = 0
 
 MAPPINGS                                        *neuron.vim-mappings*
 

--- a/plugin/neuron.vim
+++ b/plugin/neuron.vim
@@ -16,7 +16,7 @@ let g:neuron_fzf_options         = get(g:, 'neuron_fzf_options', ['-d',':','--wi
 let g:neuron_executable = get(g:, 'neuron_executable', system('which neuron | tr -d "\n"'))
 let g:neuron_fullscreen_search = get(g:, 'neuron_fullscreen_search', 0)
 
-let g:neuron_rib_job = -1
+let g:_neuron_rib_job = -1
 
 nm <silent> <Plug>NeuronRibStop :<C-U>call rpc#stop_server()<cr>
 nm <silent> <Plug>NeuronRibStart :<C-U>call rpc#start_server()<cr>
@@ -56,7 +56,7 @@ end
 com! NeuronRibStart :call rpc#start_server()
 com! NeuronRibStop  :call rpc#stop_server()
 
-let g:neuron_errors = {
+let g:_neuron_errors = {
 	\ 'E1': {
 		\ 'problem': "neuron not found",
 		\ 'suggestions': [


### PR DESCRIPTION
I noticed a few more `g:neuron_` variables that were not documented: `g:neuron_rib_job`, `g:neuron_errors`, `g:neuron_dir`, and `g:neuron_no_mappings`.

It seemed to me that some of these were probably only intended for internal use (`g:neuron_rib_job`, `g:neuron_errors`) so I renamed these to reflect that. The others I added documentation for.