### PR TITLE
Fix `new_zettel_path` cause vim to freeze on macOS

### DIFF
--- a/autoload/util.vim
+++ b/autoload/util.vim
@@ -101,7 +101,7 @@ func! util#zettel_id_from_path(path)
 endf
 
 func! util#new_zettel_path(title)
-	let l:id = system("od /dev/random -An -N 4 -t 'x4'")
+	let l:id = system("od -An -N 4 -t 'x4' /dev/random")
 	if !empty(a:title) && g:neuron_titleid
 		let l:id = a:title
 	endif


### PR DESCRIPTION
On macOS, the filename argument of `od` should be placed at the end, otherwise, the `-An -N 4 -t 'x4'` part will be treated as filenames and keep dumping /dev/random.