### PR TITLE
Resolve bareword shadowing related errors for custom ID generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,18 @@ Plug 'fiatjaf/neuron.vim'
 
 ## Customization
 
-  - `neuron.vim` uses the `g:NeuronGenerateID` function to generate ids for new zettels that it creates, bypassing `neuron new` completely. By default it generates a random hex string of 8 characters. You can redefine the `g:NeuronGenerateID` function in your `.vimrc` file to use anything you prefer. For example:
+  - `neuron.vim` uses the `g:NeuronGenerateID` function to generate ids for new zettels that it creates, bypassing `neuron new` completely. By default it generates a random hex string of 8 characters. You can hook into the `g:NeuronGenerateID` function in your `.vimrc` file to use anything you prefer as an ID, by defining a function `g:CustomNeuronIDGenerator`. For example:
 
     To make it use the title as ID (when using `gzN`) or falling back to the random on `gzn`:
 
     ```
-    func! g:NeuronGenerateID(title)
+    func! g:CustomNeuronIDGenerator(title)
     	if empty(a:title)
     		return system("od -An -N 4 -t 'x4' /dev/random")
     	endif
     	return a:title
     endf
     ```
+
+  If `g:CustomNeuronIDGenerator` is not defined in your dotfiles, `neuron.vim`
+  will fall back to generating random IDs.

--- a/doc/neuron.vim.txt
+++ b/doc/neuron.vim.txt
@@ -7,6 +7,12 @@ INTRODUCTION                                    *neuron.vim*
 neuron.vim manages your zettelkasten. You can search, create, navigate and open your zettels using fzf and neuron.
 
 CONFIGURATION                                   *neuron.vim-configuration*
+g:CustomNeuronIDGenerator   Hook function to define your own strategy for generating the
+                            IDs of new Zettel notes. Accepts a string 'title' parameter,
+                            and should return a string. If left undefined, neuron.vim will
+                            generate random IDs for new notes. Default: >
+                            undefined
+
 g:neuron_backlinks_size     Size in characters used for backlinks window. Default: >
                             let g:neuron_backlinks_size = 40
 
@@ -29,10 +35,6 @@ g:neuron_executable         Path to neuron. Default >
 g:neuron_extension          Zettel file extension. Default: >
                             let g:neuron_extension = '.md'
 
-g:NeuronGenerateID          Function called to generate an id for a new Zettel. Default: >
-                            func! RandomID(title)
-                            	return system("od -An -N 4 -t 'x4' /dev/random")
-                            endf
 
 g:neuron_fullscreen_search  If fzf searches are to occupy the entire screen. Default: >
                             let g:neuron_fullscreen_search = 0

--- a/plugin/neuron.vim
+++ b/plugin/neuron.vim
@@ -20,11 +20,18 @@ let g:neuron_fzf_options = get(g:, 'neuron_fzf_options', ['-d',':','--with-nth',
 let g:neuron_inline_backlinks = get(g:, 'neuron_inline_backlinks', 1)
 let g:neuron_no_mappings = get(g:, 'neuron_no_mappings', 0)
 
-" mega-customization through functions to generate the zettel id
 func! RandomID(title)
 	return system("od -An -N 4 -t 'x4' /dev/random")
 endf
-let g:NeuronGenerateID = get(g:, 'NeuronGenerateID', function('RandomID'))
+
+" mega-customization through functions to generate the zettel id
+func! g:NeuronGenerateID(title)
+	if exists('*g:CustomNeuronIDGenerator')
+		return g:CustomNeuronIDGenerator(a:title)
+	else
+		return RandomID(a:title)
+	endif
+endfunc
 
 let g:_neuron_rib_job = -1
 


### PR DESCRIPTION
Before this PR, if a custom ID generator was defined in `.vimrc` to override the random ID generator, vim would throw errors out when starting (but otherwise worked fine).

This PR changes the name used to provide custom generators so that it does not shadow or clash with the bareword used by the plugin (`g:NeuronGenerateID`).

It also updates the documentation in the readme.


After this commit, to change the ID generation behavior, a `g:CustomNeuronIDGenerator` function must be defined, that accepts a `title` parameter, and returns a string.

If one is not defined, the plugin continues to return IDs generated by the existing `RandomID` function.

---

## Testing

This change has been tested manually in the following cases:

- with no custom generator defined (default behavior), **Zettels are created with random IDs**
- with a custom generator defined, **Zettels are created with IDs built by the custom generator**

For reference/further testing, the generator used to test this was:

```vim
function! g:CustomNeuronIDGenerator(title)
  if empty(a:title)
   " Copied from the default generator
    return system("od -An -N 4 -t 'x4' /dev/random")
  else
    let l:lower = tolower(a:title)

    let l:text = substitute(l:lower, '\W', ' ', 'g')

    let l:text_elements = split(l:text)

    let l:kebabed_title = join(l:text_elements, '-')

    let l:random_suffix = substitute(system("od -An -N 4 -t 'x4' /dev/random"), '\W', '', 'g')
    return join([l:kebabed_title, l:random_suffix], '--')
  endif
endfunction

```

## Other considerations

This change has been made by converting what had been `let g:NeuronGenerateID` into a function, because I was running into issues where function refs were being treated as strings and Vim was throwing errors. Given that this achieves the same result, and my web searching didn't turn up an immediately identifiable fix, I went with this. Like I said before, vimscript is new to me, so I'm very open to the idea that I've reinvted a wheel somehow or something :sweat_smile:
