### PR TITLE
Fix autocmd filename escape on Linux

### DIFF
--- a/ftdetect/neuron.vim
+++ b/ftdetect/neuron.vim
@@ -13,8 +13,8 @@ endif
 
 if exists('b:did_ftdetect') | finish | endif
 aug neuron
-	exec ':au! BufRead '.fnameescape(g:neuron_dir.'*'.g:neuron_extension).' call neuron#add_virtual_titles()'
-	exec ':au! BufEnter '.fnameescape(g:neuron_dir.'*'.g:neuron_extension).' call neuron#on_enter()'
-	exec ':au! BufWrite '.fnameescape(g:neuron_dir.'*'.g:neuron_extension).' call neuron#on_write()'
+	exec ':au! BufRead '.fnameescape(g:neuron_dir).'*'.fnameescape(g:neuron_extension).' call neuron#add_virtual_titles()'
+	exec ':au! BufEnter '.fnameescape(g:neuron_dir).'*'.fnameescape(g:neuron_extension).' call neuron#on_enter()'
+	exec ':au! BufWrite '.fnameescape(g:neuron_dir).'*'.fnameescape(g:neuron_extension).' call neuron#on_write()'
 aug END
 let b:did_ftdetect = 1


### PR DESCRIPTION
Previously, the `fnameescape()` causes the wildcard asterisk to be escaped in the pattern - resulting in e.g. `/my/neuron/dir/\*.md` - which unfortunately doesn't set the autocommands correctly on my system (Linux/Neovim). (Not sure if this applies to Vim or other OSes.)

This PR prevents the wildcard from being escaped.