### PR TITLE
Note nix installation option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,21 @@ Plug 'junegunn/fzf.vim'
 Plug 'fiatjaf/neuron.vim'
 ```
 
+### Using [home-manager](https://github.com/rycee/home-manager)
+There are several ways to manage {n}vim plugins with home-manager. The current release has been tested with the `programs.neovim` module (tracking nixpkgs-unstable) like so:
+```nix
+{
+  programs.neovim = {
+    enable = true;
+    plugins = with pkgs.vimPlugins; [
+      neuron-vim
+      # ...
+    ];
+  };
+  # ...
+}
+```
+
 ## Usage
 
 1. Open a zettel with `vim` or `nvim`. On `nvim` it should


### PR DESCRIPTION
Following up on https://github.com/fiatjaf/neuron.vim/issues/28#issuecomment-723274398

- [rendered](https://github.com/fiatjaf/neuron.vim/blob/744ba79d7e5d0caff4ce527479faf7e595fb9187/README.md#using-home-manager)