### PR TITLE
Set search directory in content search

### DIFF
--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -104,7 +104,7 @@ func! neuron#search_content(use_cursor)
 	if a:use_cursor
 		let l:query = expand("<cword>")
 	endif
-	call fzf#vim#ag(l:query, fzf#vim#with_preview({'options': '--exact'}), g:neuron_fullscreen_search)
+	call fzf#vim#ag(l:query, fzf#vim#with_preview({'dir': g:neuron_dir, 'options': '--exact'}), g:neuron_fullscreen_search)
 endf
 
 func! neuron#edit_zettel_select()


### PR DESCRIPTION
Use `g:neuron_dir` instead of cwd for content search. I don't think this is needed for the other searches, because they use the cache.