### PR TITLE
Define neuron_dir so that it is available for nix installs

### DIFF
--- a/ftdetect/neuron.vim
+++ b/ftdetect/neuron.vim
@@ -1,10 +1,4 @@
 let g:neuron_extension = get(g:, 'neuron_extension', '.md')
-let g:neuron_dir = get(g:, 'neuron_dir', fnamemodify(expand("%:p"), ":h")."/")
-
-" fallback to using getcwd if the above gives us a relative path
-if g:neuron_dir == './'
-	let g:neuron_dir = getcwd() . "/"
-endif
 
 " if there is no neuron.dhall file in current dir then it is not a zettelkasten
 if !filereadable(g:neuron_dir."neuron.dhall")

--- a/ftdetect/neuron.vim
+++ b/ftdetect/neuron.vim
@@ -1,14 +1,15 @@
 let g:neuron_extension = get(g:, 'neuron_extension', '.md')
+let b:neuron_dir = get(g:, 'neuron_dir')
 
 " if there is no neuron.dhall file in current dir then it is not a zettelkasten
-if !filereadable(g:neuron_dir."neuron.dhall")
+if !filereadable(b:neuron_dir."neuron.dhall")
 	finish
 endif
 
 if exists('b:did_ftdetect') | finish | endif
 aug neuron
-	exec ':au! BufRead '.fnameescape(g:neuron_dir).'*'.fnameescape(g:neuron_extension).' call neuron#add_virtual_titles()'
-	exec ':au! BufEnter '.fnameescape(g:neuron_dir).'*'.fnameescape(g:neuron_extension).' call neuron#on_enter()'
-	exec ':au! BufWrite '.fnameescape(g:neuron_dir).'*'.fnameescape(g:neuron_extension).' call neuron#on_write()'
+	exec ':au! BufRead '.fnameescape(b:neuron_dir).'*'.fnameescape(b:neuron_extension).' call neuron#add_virtual_titles()'
+	exec ':au! BufEnter '.fnameescape(b:neuron_dir).'*'.fnameescape(b:neuron_extension).' call neuron#on_enter()'
+	exec ':au! BufWrite '.fnameescape(b:neuron_dir).'*'.fnameescape(b:neuron_extension).' call neuron#on_write()'
 aug END
 let b:did_ftdetect = 1

--- a/plugin/neuron.vim
+++ b/plugin/neuron.vim
@@ -11,6 +11,13 @@ if exists("g:_neuron_loaded")
 endif
 let g:_neuron_loaded = 1
 
+let g:neuron_dir = get(g:, 'neuron_dir', fnamemodify(expand("%:p"), ":h")."/")
+
+" fallback to using getcwd if the above gives us a relative path
+if g:neuron_dir == './'
+	let g:neuron_dir = getcwd() . "/"
+endif
+
 let g:neuron_backlinks_size = get(g:, 'neuron_backlinks_size', 40)
 let g:neuron_backlinks_vsplit = get(g:, 'neuron_backlinks_vsplit', 1)
 let g:neuron_backlinks_vsplit_right = get(g:, 'neuron_backlinks_vsplit_right', 1)


### PR DESCRIPTION
This minor change makes it possible again to install the plugin through nix #50 

After looking through the code I realized that the ``g:neuron_dir`` variable is set already in ``ftdetect/neuron.vim``, however this wasn't available in ``plugin/neuron.vim`` and so the nix install failed. 

Simply moving the lines from one file to the other fixed the problem. If there are any unwanted side-effects that could occur, or if you prefer to merge differently let me know
