### PR TITLE
properly supply cwd when performing ftdetect

### DIFF
--- a/ftdetect/neuron.vim
+++ b/ftdetect/neuron.vim
@@ -1,5 +1,5 @@
 let g:neuron_extension = get(g:, 'neuron_extension', '.md')
-let b:neuron_dir = get(g:, 'neuron_dir')
+let b:neuron_dir = get(g:, 'neuron_dir', getcwd() . '/')
 
 " if there is no neuron.dhall file in current dir then it is not a zettelkasten
 if !filereadable(b:neuron_dir."neuron.dhall")


### PR DESCRIPTION
While running neuron on my system I noticed that ftdetect wasn't creating the augroups because `get(g:, 'neuron_dir')` returned 0 instead of the current directory as expected. I was able to work around this issue by supplying an explicit default to `get`.