### PR TITLE
pipe stderr to /dev/null so it is ignored when fetching tags

### DIFF
--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -632,7 +632,7 @@ endfunc
 " Add tags from a selection list
 func! neuron#tags_add_select()
 	" TODO: use cache
-	let l:cmd = g:neuron_executable.' -d "'.g:neuron_dir.'" query -u z:tags'
+	let l:cmd = g:neuron_executable.' -d "'.g:neuron_dir.'" query -u z:tags 2>/dev/null'
 	let l:data = system(l:cmd)
 	let l:tags = json_decode(l:data)["result"]
 	if empty(l:tags)


### PR DESCRIPTION
I was getting output like this when querying for tags
```
$ /Users/devin/.nix-profile/bin/neuron -d "/Users/devin/Library/Mobile Documents/com~apple~CloudDocs/notes/" query -u z:tags
[D] Plugins enabled: dirtree, neuronignore
[D] Loading directory tree (5 .md files) ...
[D] Building zettelkasten graph (5 zettels) ...
{"skipped":{},"result":[{"children":[{"children":[],"count":1,"name":"feature"},{"children":[],"count":1,"name":"query"}],"count":1,"name":"graph"},{"children":[],"count":4,"name":"root"},{"children":[],"count":1,"name":"version-control"}],"query":["ZettelQuery_Tags",{"tag":"TagQuery_All"}]}
```

The debug output was causing an error like this when trying to fetch the
tags:
```
Error detected while processing function neuron#tags_add_select:
line    4:
E474: Unidentified byte: ^[[90m[D] Plugins enabled: dirtree, neuronignore^[[0m^@^[[90
m[D] Loading directory tree (5 .md files) ...^[[0m^@^[[90m[D] Building zettelkasten g
raph (5 zettels) ...^[[0m^@{"skipped":{},"result":[{"children":[{"children":[],"count
":1,"name":"feature"},{"children":[],"count":1,"name":"query"}],"count":1,"name":"gra
ph"},{"children":[],"count":4,"name":"root"},{"children":[],"count":1,"name":"version
-control"}],"query":["ZettelQuery_Tags",{"tag":"TagQuery_All"}]}^@
E474: Failed to parse ^[[90m[D] Plugins enabled: dirtree, neuronignore^[[0m^@^[[90m[D
] Loading directory tree (5 .md files) ...^[[0m^@^[[90m[D] Building zettelkasten grap
h (5 zettels) ...^[[0m^@{"skipped":{},"result":[{"children":[{"children":[],"count":1
,"name":"feature"},{"children":[],"count":1,"name":"query"}],"count":1,"name":"graph"
},{"children":[],"count":4,"name":"root"},{"children":[],"count":1,"name":"version-co
ntrol"}],"query":["ZettelQuery_Tags",{"tag":"TagQuery_All"}]}^@
line   12:
E714: List required
Press ENTER or type command to continue
```

It looks like what was happening is system() passes both stderr/stdout
together which was making l:data invalid json, which caused json_decode
to fail.

With fix, we ignore stderr, which causes the json to be parsed properly.