### PR TITLE
support as_folgezettel parameter for insert_new_from_cword and insert_new_from_visual

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.vim]
+indent_style=tab
+
+[*.vader]
+indent_style=space
+indent_size=2

--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -190,39 +190,12 @@ func! neuron#edit_zettel_new()
 endf
 
 func! neuron#edit_zettel_new_from_cword(as_folgezettel)
-	let l:title = expand("<cword>")
-	let l:zettel_path = util#new_zettel_path(l:title)
-
-	" replace cword with a link to the new zettel
-	let l:zettel_id = util#zettel_id_from_path(l:zettel_path)
-
-	" we need to be fairly careful here to make sure that we insert the
-	" link in the same position in the line where it started: there are
-	" essentially three cases
-	" 1. the word is at the beginning or middle of the line
-	" 2. the word is at the end of the line
-	" 3. the word is at the end of the line followed by a single character
-	" We need to enter insert mode via i if there is already a character
-	" following the word that will be replaced so that we insert the link before
-	" the word boundary (cases 1 and 3) and we need to enter insert mode via a
-	" if there isn't a following character (i.e. we are in case 2)
-	" To detect which case we are in, we first note the current position, then
-	" go to the end of the word and check if the current position is the last
-	" character in the line, then restore the original position after
-	" determining which case we are in.
-	let l:pos = getpos('.')
-	execute "normal! e"
-	let l:mode_transition = col('.') == col('$') - 1 ? "a" : "i"
-	call setpos('.', l:pos)
-
-	execute "normal! diw"
-	call util#insert(l:zettel_id, a:as_folgezettel, l:mode_transition)
-	call neuron#add_virtual_titles()
-	w
-
-	exec 'edit '.l:zettel_path
-	call util#add_empty_zettel_body(l:title)
-	let g:_neuron_must_refresh_on_write = 1
+	let l:vstart_prev = getpos("'<")
+	let l:vend_prev = getpos("'>")
+	execute "normal! viwv"
+	call neuron#edit_zettel_new_from_visual(a:as_folgezettel)
+	call setpos("'<", l:vstart_prev)
+	call setpos("'>", l:vend_prev)
 endf
 
 func! neuron#edit_zettel_new_from_visual(as_folgezettel)

--- a/autoload/neuron.vim
+++ b/autoload/neuron.vim
@@ -70,6 +70,7 @@ func! neuron#insert_zettel_complete(as_folgezettel)
 		let l:reducer_to_use = 'neuron#insert_reducer_folgezettel'
 	else
 		let l:reducer_to_use = 'neuron#insert_reducer'
+
 	endif
 
 	return call('fzf#vim#complete', [fzf#wrap({
@@ -176,7 +177,7 @@ func! neuron#insert_zettel_last(as_folgezettel)
 		return
 	endif
 	let l:zettelid = util#zettel_id_from_path(g:_neuron_last_file)
-	call util#insert(l:zettelid, a:as_folgezettel)
+	call util#insert(l:zettelid, a:as_folgezettel, "a")
 endf
 
 func! neuron#edit_zettel_new()
@@ -188,13 +189,18 @@ func! neuron#edit_zettel_new()
 	call util#add_empty_zettel_body('')
 endf
 
-func! neuron#edit_zettel_new_from_cword()
+func! neuron#edit_zettel_new_from_cword(as_folgezettel)
 	let l:title = expand("<cword>")
 	let l:zettel_path = util#new_zettel_path(l:title)
 
 	" replace cword with a link to the new zettel
 	let l:zettel_id = util#zettel_id_from_path(l:zettel_path)
-	execute "normal! ciw[[[".l:zettel_id."]]]"
+	execute "normal! diw"
+
+	" if the cursor is in the last position on the line, append so that we don't
+	" smoosh together the inserted zettel with the word before it
+	let mode_transition = col('.') == col('$') - 1 ? "a" : "i"
+	call util#insert(l:zettel_id, a:as_folgezettel, l:mode_transition)
 	call neuron#add_virtual_titles()
 	w
 
@@ -203,7 +209,7 @@ func! neuron#edit_zettel_new_from_cword()
 	let g:_neuron_must_refresh_on_write = 1
 endf
 
-func! neuron#edit_zettel_new_from_visual()
+func! neuron#edit_zettel_new_from_visual(as_folgezettel)
 	let l:prev = @p
 
 	" title from visual selection
@@ -217,7 +223,10 @@ func! neuron#edit_zettel_new_from_visual()
 	""" replace selection with a link to the new zettel
 	let l:zettel_id = util#zettel_id_from_path(l:zettel_path)
 
-	execute "normal! a[[[".l:zettel_id."]]]"
+	" if the cursor is in the last position on the line, append so that we don't
+	" smoosh together the inserted zettel with the word before it
+	let mode_transition = col('.') == col('$') - 1 ? "a" : "i"
+	call util#insert(l:zettel_id, a:as_folgezettel, l:mode_transition)
 	call neuron#add_virtual_titles()
 	w
 

--- a/autoload/util.vim
+++ b/autoload/util.vim
@@ -1,4 +1,11 @@
-func! util#insert(zettelid, as_folgezettel)
+" Mode transition specifies how to enter insert mode, usually either 'a' or
+" 'i'. This extra parameter is necessary for properly handling replacement.
+" Consider for example the case of executing neuron#edit_zettel_from_visual on
+" text starting in the first position on the line. The cursor ends up in the
+" first position in the line, and appending would cause the new link to be
+" offset by a space, whereas the desired result is having the new link
+" start at the first character.
+func! util#insert(zettelid, as_folgezettel, mode_transition)
 	if a:as_folgezettel
 		let l:formatted = "[[[".a:zettelid."]]]"
 	else
@@ -10,7 +17,7 @@ func! util#insert(zettelid, as_folgezettel)
 		" erase things like '[[]]' before adding
 		execute "normal! diwi".l:formatted
 	else
-		execute "normal! a".l:formatted
+		execute "normal! ".a:mode_transition.l:formatted
 	endif
 
 	call neuron#add_virtual_titles()
@@ -51,11 +58,11 @@ func! util#deform_zettelid(zettelid)
 endf
 
 func! util#insert_shrink_fzf(line)
-	call util#insert(util#get_zettel_from_fzf_line(a:line), 0)
+	call util#insert(util#get_zettel_from_fzf_line(a:line), 0, "a")
 endf
 
 func! util#insert_shrink_fzf_folgezettel(line)
-	call util#insert(util#get_zettel_from_fzf_line(a:line), 1)
+	call util#insert(util#get_zettel_from_fzf_line(a:line), 1, "a")
 endf
 
 func! util#edit_shrink_fzf(line)

--- a/plugin/neuron.vim
+++ b/plugin/neuron.vim
@@ -34,8 +34,8 @@ let g:neuron_tmp_filename = get(g:, 'neuron_tmp_filename', '/tmp/neuronzettelsbu
 nm <silent> <Plug>EditZettelNew :<C-U>call neuron#edit_zettel_new()<cr>
 nm <silent> <Plug>EditZettelSearchContent :<C-U>call neuron#search_content(0)<cr>
 nm <silent> <Plug>EditZettelSearchContentUnderCursor :<C-U>call neuron#search_content(1)<cr>
-nm <silent> <Plug>EditZettelNewFromCword :<C-U>call neuron#edit_zettel_new_from_cword()<cr>
-nm <silent> <Plug>EditZettelNewFromVisual :<C-U>call neuron#edit_zettel_new_from_visual()<cr>
+nm <silent> <Plug>EditZettelNewFromCword :<C-U>call neuron#edit_zettel_new_from_cword(1)<cr>
+nm <silent> <Plug>EditZettelNewFromVisual :<C-U>call neuron#edit_zettel_new_from_visual(1)<cr>
 nm <silent> <Plug>EditZettelLast :<C-U>call neuron#edit_zettel_last()<cr>
 nm <silent> <Plug>NeuronRefreshCache :<C-U>call neuron#refresh_cache(1)<cr>
 nm <silent> <Plug>EditZettelSelect :<C-U>call neuron#edit_zettel_select()<cr>


### PR DESCRIPTION
Allow these two methods to optionally only create a normal link.

I also fix a bug:
If one considers the following text (`^` and `$` inserted to emphasize the beginning / end of the line, not actually present in text)
```
^test1 test2 test3$
```
and calls `neuron#insert_new_from_cword` (or `neuron#insert_new_from_visual`) at each of these positions there is sometimes bad behavior.

for test1 and test2 the resulting document is currently correct, respectively:
```
^[[new_id]] test2 test3$
```
and
```
^test1 [[new_id]] test3$
```

but for test3 it is:
```
^test1 test2[[test3]] $
```
instead of
```
^test1 test2 [[test3]]$
```
as expected.

I also fix this behavior.

Furthermore I add an .editorconfig file to ensure that tabs/spaces stay intact for this repository and mixed spaces/tabs aren't introduced (of course this does require people to have https://github.com/editorconfig/editorconfig-vim installed.